### PR TITLE
增加SPS和PPS的重新发送

### DIFF
--- a/server.go
+++ b/server.go
@@ -97,6 +97,14 @@ func (sh *RTSPServer) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*ba
 			}
 			var st uint32
 			onVideo := func(ts uint32, pack *engine.VideoPack) {
+				if pack.IDR {
+					for _, nalu := range sub.vt.ExtraData.NALUs {
+						for _, packet := range vpacketer.Packetize(nalu, 0) {
+							buf, _ := packet.Marshal()
+							stream.WritePacketRTP(trackId, buf)
+						}
+					}
+				}
 				for i, nalu := range pack.NALUs {
 					var samples uint32
 					if i == len(pack.NALUs)-1 {


### PR DESCRIPTION
当SPS和PPS发生变更时，每次I帧都重新发送SPS和PPS，组成IDR帧，用于客户端修正数据